### PR TITLE
Fix SSL option sending HTTP request

### DIFF
--- a/SharpExchangePriv/Program.cs
+++ b/SharpExchangePriv/Program.cs
@@ -66,11 +66,11 @@ namespace SharpExchangePriv
             string URL = "";
             if (SSL)
             {
-                URL = "http://" + targetHost + ":" + ExchangePort + "/EWS/Exchange.asmx";
+                URL = "https://" + targetHost + ":" + ExchangePort + "/EWS/Exchange.asmx";
             }
             else
             {
-                URL = "https://" + targetHost + ":" + ExchangePort + "/EWS/Exchange.asmx";
+                URL = "http://" + targetHost + ":" + ExchangePort + "/EWS/Exchange.asmx";
             }
             
             Console.WriteLine("The target URL is {0}\n", URL);


### PR DESCRIPTION
When "--ssl"/"-s" option was set, the program requested the exchange server through HTTP instead of HTTPS (and vice-versa, when the option was not set, the program requested the exchange server through HTTPS).